### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Pre-submission checklist:
+
+Please check each of these after submitting your pull request:
+
+- [ ] If this is a new entry, have you submitted a signed [participation form](https://github.com/cncf/cnf-certification/blob/main/Certified_CNF_Form.md)?
+- [ ] Did you include the product/project logo in SVG, EPS or AI format?
+- [ ] Does your logo clearly state the name of the product/project/org and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
+- [ ] If your product/project is open source, did you include the repo_url?
+- [ ] Did you copy and paste the [installation and configuration instructions](https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions) into the README.md file in addition to linking to them?


### PR DESCRIPTION
Create a template for cnf cert

Known issues:
- last checkbox refers to https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions
- need to create an FAQ and version of these instructions for cnf cert