### PR TITLE
Update Certified_CNF_Terms.md - docusign link removed

### DIFF
--- a/Certified_CNF_Terms.md
+++ b/Certified_CNF_Terms.md
@@ -39,7 +39,7 @@ In order to be a Participant in the Certification Program and to use the Certifi
 
 1. determine those of its goods and services with which it intends to use with the Certified CNF Marks;
 2. confirm through self-testing that those goods and services are Qualifying Offerings, as described herein;
-3. submit to The Linux Foundation a signed Participation Form (by email to cnfcertification@cncf.io, by[ ](https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=ba08f93a-65ca-4c5d-8210-d5c858bb9208)[DocuSign](https://na4.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=cb6ee2b7-ee9d-48c5-b154-abfab626a21f&env=na4&acct=99530ead-94da-4299-b0ca-9df20e86a064&v=2) or other method made available by The Linux Foundation), designating the applicable Qualifying Offerings and accepting the terms and conditions of the Certification Program;
+3. submit to The Linux Foundation a signed Participation Form (by email to cnfcertification@cncf.io or another method made available by The Linux Foundation), designating the applicable Qualifying Offerings and accepting the terms and conditions of the Certification Program;
 4. submit to the Cloud Native Computing Foundation ("CNCF") the successfully-passing self-testing results for the Qualifying Offerings, and have the results accepted by CNCF;
 5. pay fees (if any) required for its participation in the Certification Program; and
 6. abide by the terms and conditions of the Certification Program, including subsequent re-testing as described herein, throughout the period of the Participant’s use of the Certified CNF Marks.

--- a/faq.md
+++ b/faq.md
@@ -4,7 +4,7 @@
 For [members](https://www.cncf.io/about/members/) of the Cloud Native Computing Foundation, there is no charge for certification. There is also no charge for non-profit organizations. For commercial organizations that wish to certify but don't want to become a CNCF member, the fee is the same as [joining](https://www.cncf.io/about/join/) the CNCF.
 
 ## Is a participation form required per company or per product?
-Per product. Each separate product (i.e., different product name) from your company requires a different [participation form](https://github.com/cncf/cnf-certification/blob/main/Certified_CNF_Form.md). Submit a signed Participation Form using [DocuSign](https://na4.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=cb6ee2b7-ee9d-48c5-b154-abfab626a21f&env=na4&acct=99530ead-94da-4299-b0ca-9df20e86a064&v=2).
+Per product. Each separate product (i.e., different product name) from your company requires a different [participation form](https://github.com/cncf/cnf-certification/blob/main/Certified_CNF_Form.md). Submit a form to cnfcertification@cncf.io or another method made available by The Linux Foundation.
 
 ## How is CNF Certification different from other conformance efforts?
 While many network certifications test Kubernetes platform properties and Cloud Native Network Function (CNF) connectivity, CNCF’s CNF Certification Program gives insights into a CNF's installability, interoperability, and resilience. The certification also promotes workload self-healing as a highly desired, cloud native property.


### PR DESCRIPTION
Removing docusign link.  Use email cncfcertification@cncf.io for submitting participation form